### PR TITLE
Add Fabric Text Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 /adapter-bungeecord/out/
 /adapter-spongeapi/build/
 /adapter-spongeapi/out/
+/adapter-fabric/build/
+/adapter-fabric/out/
 /run/
 /*.iml

--- a/adapter-fabric/build.gradle
+++ b/adapter-fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.2.6-SNAPSHOT'
+    id 'fabric-loom'
 }
 
 dependencies {
@@ -9,3 +9,5 @@ dependencies {
     mappings 'net.fabricmc:yarn:1.14.4+build.15:v2'
     modCompile 'net.fabricmc:fabric-loader:0.7.2+build.175'
 }
+
+

--- a/adapter-fabric/build.gradle
+++ b/adapter-fabric/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'fabric-loom' version '0.2.6-SNAPSHOT'
+}
+
+dependencies {
+    api 'net.kyori:text-api:3.0.0'
+    api 'net.kyori:text-serializer-gson:3.0.0'
+    minecraft 'com.mojang:minecraft:1.14.4'
+    mappings 'net.fabricmc:yarn:1.14.4+build.15:v2'
+    modCompile 'net.fabricmc:fabric-loader:0.7.2+build.175'
+}

--- a/adapter-fabric/src/main/java/net/kyori/text/adapter/fabric/TextAdapter.java
+++ b/adapter-fabric/src/main/java/net/kyori/text/adapter/fabric/TextAdapter.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of text-extras, licensed under the MIT License.
+ *
+ * Copyright (c) 2018 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.text.adapter.fabric;
+
+import java.util.Collections;
+import net.kyori.text.Component;
+import net.kyori.text.serializer.gson.GsonComponentSerializer;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * An adapter for sending text {@link Component}s to Fabric objects.
+ */
+public interface TextAdapter {
+  /**
+   * Sends {@code component} to the given {@code viewer}.
+   *
+   * <p>Note that all Entities implement {@link CommandOutput}.</p>
+   *
+   * @param viewer the viewer to send the component to
+   * @param component the component
+   */
+  static void sendComponent(final @NonNull CommandOutput viewer, final @NonNull Component component) {
+    sendComponent(Collections.singleton(viewer), component);
+  }
+
+  /**
+   * Sends {@code component} to the given {@code viewers}.
+   *
+   * <p>Note that all Entities implement {@link CommandOutput}.</p>
+   *
+   * @param viewers the viewers to send the component to
+   * @param component the component
+   */
+  static void sendComponent(final @NonNull Iterable<? extends CommandOutput> viewers, final @NonNull Component component) {
+    final Text text = Text.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(component));
+    for(final CommandOutput viewer : viewers) {
+      viewer.sendMessage(text);
+    }
+  }
+  /**
+   * Sends {@code component} to the given {@code viewer}.
+   *
+   * @param viewer the viewer to send the component to
+   * @param component the component
+   * @param broadcastToOperators whether this component should be broadcast to operators
+   */
+  static void sendComponent(final @NonNull ServerCommandSource viewer, final @NonNull Component component, final boolean broadcastToOperators) {
+    sendComponent(Collections.singleton(viewer), component, broadcastToOperators);
+  }
+
+  /**
+   * Sends {@code component} to the given {@code viewers}.
+   *
+   * @param viewers the viewers to send the component to
+   * @param component the component
+   * @param broadcastToOperators whether this component should be broadcast to operators
+   */
+  static void sendComponent(final @NonNull Iterable<? extends ServerCommandSource> viewers, final @NonNull Component component, final boolean broadcastToOperators) {
+    final Text text = Text.Serializer.fromJson(GsonComponentSerializer.INSTANCE.serialize(component));
+    for(final ServerCommandSource viewer : viewers) {
+      viewer.sendFeedback(text, broadcastToOperators);
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,14 @@ buildscript {
     maven {
       url 'https://plugins.gradle.org/m2/'
     }
+    maven {
+      url 'https://maven.fabricmc.net/'
+    }
   }
 
   dependencies {
     classpath 'gradle.plugin.net.minecrell:licenser:0.4.1'
+    classpath 'net.fabricmc:fabric-loom:0.2.6-20191213.183106-50'
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,3 @@
-// This is required for adapter-fabric
-pluginManagement {
-    repositories {
-        jcenter()
-        maven {
-            url = 'https://maven.fabricmc.net/'
-        }
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'text-extras-parent'
 
 include 'adapter-bukkit'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,14 @@
+// This is required for adapter-fabric
+pluginManagement {
+    repositories {
+        jcenter()
+        maven {
+            url = 'https://maven.fabricmc.net/'
+        }
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'text-extras-parent'
 
 include 'adapter-bukkit'
@@ -8,3 +19,6 @@ findProject(':adapter-bungeecord')?.name = 'text-adapter-bungeecord'
 
 include 'adapter-spongeapi'
 findProject(':adapter-spongeapi')?.name = 'text-adapter-spongeapi'
+
+include 'adapter-fabric'
+findProject(':adapter-fabric')?.name = 'text-adapter-fabric'


### PR DESCRIPTION
The basic implementation is in, the only thing which needs to be changed is to fix the build for fabric since codesigning seems to conflict with fabric's `remapSourcesJar` task. Hence why it is a draft PR for now.

This is build error:
`Cannot call Task.dependsOn(Object...) on task ':text-adapter-fabric:signArchives' after task has started execution.`

Related to #11 