### PR TITLE
Add ColorSerializer to Bungee's gson instance to prevent illegal reflection warnings

### DIFF
--- a/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/BungeeComponentSerializer.java
+++ b/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/BungeeComponentSerializer.java
@@ -25,6 +25,7 @@ package net.kyori.adventure.text.serializer.bungeecord;
 
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonWriter;
+import java.awt.Color;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import net.kyori.adventure.text.Component;
@@ -110,6 +111,7 @@ public final class BungeeComponentSerializer implements ComponentSerializer<Comp
     final boolean result = GsonInjections.injectGson(requireNonNull(existing, "existing"), builder -> {
       GsonComponentSerializer.gson().populator().apply(builder); // TODO: this might be unused?
       builder.registerTypeAdapterFactory(new SelfSerializable.AdapterFactory());
+      builder.registerTypeAdapter(Color.class, new ColorSerializer());
     });
     SUPPORTED &= result;
     return result;

--- a/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/ColorSerializer.java
+++ b/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/ColorSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of adventure-platform, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.text.serializer.bungeecord;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.awt.Color;
+import java.lang.reflect.Type;
+
+final class ColorSerializer implements JsonDeserializer<Color>, JsonSerializer<Color> {
+  @Override
+  public Color deserialize(final JsonElement json, final Type typeOfT, final JsonDeserializationContext context) throws JsonParseException {
+    return new Color(json.getAsInt());
+  }
+
+  @Override
+  public JsonElement serialize(final Color src, final Type typeOfSrc, final JsonSerializationContext context) {
+    return new JsonPrimitive(src.getRGB() & 0xffffff);
+  }
+}


### PR DESCRIPTION
Users updating to Java 11 have started to commonly report warnings like these:
```
[Server] INFO WARNING: An illegal reflective access operation has occurred
[Server] INFO WARNING: Illegal reflective access by com.google.gson.internal.bind.ReflectiveTypeAdapterFactory (file:/cache/patched_1.16.4.jar) to field java.awt.Color.value
[Server] INFO WARNING: Please consider reporting this to the maintainers of com.google.gson.internal.bind.ReflectiveTypeAdapterFactory
[Server] INFO WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
[Server] INFO WARNING: All illegal access operations will be denied in a future release
```
Personally I just ignore these warnings, but for some users these warnings can cause quite a bit of confusion. I tracked the source of the warning to when I convert from Adventure to Bungee components (in order to use certain Paper APIs) using `adventure-text-serializer-bungeecord` on Java 9+. By registering a type adapter for `java.awt.Color`, we can avoid having these warnings. The adapter used in this PR is taken from [here](https://github.com/KyoriPowered-Graveyard/polar/blob/master/src/main/java/net/kyori/polar/util/ColorSerializer.java)