### PR TITLE
Add ability to specify custom component renderers

### DIFF
--- a/api/src/main/java/net/kyori/adventure/platform/AudienceProvider.java
+++ b/api/src/main/java/net/kyori/adventure/platform/AudienceProvider.java
@@ -25,8 +25,10 @@ package net.kyori.adventure.platform;
 
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -122,6 +124,22 @@ public interface AudienceProvider extends AutoCloseable {
    * @since 4.0.0
    */
   @NonNull Audience server(final @NonNull String serverName);
+
+  /**
+   * Gets the active locale-based renderer for operations on provided audiences.
+   *
+   * @return Active renderer
+   * @since 4.0.0
+   */
+  ComponentRenderer<Locale> localeRenderer();
+
+  /**
+   * Sets the active locale-based renderer for operations on provided audiences.
+   *
+   * @param renderer Active renderer
+   * @since 4.0.0
+   */
+  void localeRenderer(final @NonNull ComponentRenderer<Locale> renderer);
 
   /**
    * Closes the provider and forces audiences to be empty.

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
@@ -81,8 +81,11 @@ final class BukkitAudience extends FacetAudience<CommandSender> {
 
   private final @NonNull Plugin plugin;
 
-  BukkitAudience(final @NonNull Plugin plugin, final @NonNull Collection<CommandSender> viewers, final @Nullable Locale locale) {
-    super(viewers, locale, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
+  BukkitAudience(final @NonNull BukkitAudiencesImpl audienceProvider,
+                 final @NonNull Plugin plugin,
+                 final @NonNull Collection<CommandSender> viewers,
+                 final @Nullable Locale locale) {
+    super(viewers, locale, audienceProvider, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
     this.plugin = plugin;
   }
 

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
@@ -159,7 +159,7 @@ final class BukkitAudiencesImpl extends FacetAudienceProvider<CommandSender, Buk
   @NonNull
   @Override
   protected BukkitAudience createAudience(final @NonNull Collection<CommandSender> viewers) {
-    return new BukkitAudience(this.plugin, viewers, null);
+    return new BukkitAudience(this, this.plugin, viewers, null);
   }
 
   /**

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudience.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudience.java
@@ -45,7 +45,8 @@ final class BungeeAudience extends FacetAudience<CommandSender> {
     BungeeFacet.TabList::new
   );
 
-  BungeeAudience(final @NonNull Collection<? extends CommandSender> viewers) {
-    super(viewers, null, CHAT, ACTION_BAR, TITLE, null, null, BOSS_BAR, TAB_LIST);
+  BungeeAudience(final @NonNull BungeeAudiencesImpl audienceProvider,
+                 final @NonNull Collection<? extends CommandSender> viewers) {
+    super(viewers, null, audienceProvider, CHAT, ACTION_BAR, TITLE, null, null, BOSS_BAR, TAB_LIST);
   }
 }

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
@@ -146,7 +146,7 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
   @NonNull
   @Override
   protected BungeeAudience createAudience(final @NonNull Collection<CommandSender> viewers) {
-    return new BungeeAudience(viewers);
+    return new BungeeAudience(this, viewers);
   }
 
   @Override

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
@@ -88,16 +88,16 @@ public class FacetAudience<V> implements Audience, Closeable {
    */
   @SuppressWarnings({"unchecked", "rawtypes"}) // Without suppression, this constructor becomes unreadable
   public FacetAudience(
-          final @NonNull Collection<? extends V> viewers,
-          final @Nullable Locale locale,
-          final @NonNull FacetAudienceProvider audienceProvider,
-          final @Nullable Collection<? extends Facet.Chat> chat,
-          final @Nullable Collection<? extends Facet.ActionBar> actionBar,
-          final @Nullable Collection<? extends Facet.Title> title,
-          final @Nullable Collection<? extends Facet.Sound> sound,
-          final @Nullable Collection<? extends Facet.Book> book,
-          final @Nullable Collection<? extends Facet.BossBar.Builder> bossBar,
-          final @Nullable Collection<? extends Facet.TabList> tabList
+      final @NonNull Collection<? extends V> viewers,
+      final @Nullable Locale locale,
+      final @NonNull FacetAudienceProvider audienceProvider,
+      final @Nullable Collection<? extends Facet.Chat> chat,
+      final @Nullable Collection<? extends Facet.ActionBar> actionBar,
+      final @Nullable Collection<? extends Facet.Title> title,
+      final @Nullable Collection<? extends Facet.Sound> sound,
+      final @Nullable Collection<? extends Facet.Book> book,
+      final @Nullable Collection<? extends Facet.BossBar.Builder> bossBar,
+      final @Nullable Collection<? extends Facet.TabList> tabList
   ) {
     this.viewers = new CopyOnWriteArraySet<>();
     this.locale = locale == null ? Locale.US : locale;

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
@@ -88,16 +88,16 @@ public class FacetAudience<V> implements Audience, Closeable {
    */
   @SuppressWarnings({"unchecked", "rawtypes"}) // Without suppression, this constructor becomes unreadable
   public FacetAudience(
-      final @NonNull Collection<? extends V> viewers,
-      final @Nullable Locale locale,
-      final @NonNull FacetAudienceProvider audienceProvider,
-      final @Nullable Collection<? extends Facet.Chat> chat,
-      final @Nullable Collection<? extends Facet.ActionBar> actionBar,
-      final @Nullable Collection<? extends Facet.Title> title,
-      final @Nullable Collection<? extends Facet.Sound> sound,
-      final @Nullable Collection<? extends Facet.Book> book,
-      final @Nullable Collection<? extends Facet.BossBar.Builder> bossBar,
-      final @Nullable Collection<? extends Facet.TabList> tabList
+    final @NonNull Collection<? extends V> viewers,
+    final @Nullable Locale locale,
+    final @NonNull FacetAudienceProvider audienceProvider,
+    final @Nullable Collection<? extends Facet.Chat> chat,
+    final @Nullable Collection<? extends Facet.ActionBar> actionBar,
+    final @Nullable Collection<? extends Facet.Title> title,
+    final @Nullable Collection<? extends Facet.Sound> sound,
+    final @Nullable Collection<? extends Facet.Book> book,
+    final @Nullable Collection<? extends Facet.BossBar.Builder> bossBar,
+    final @Nullable Collection<? extends Facet.TabList> tabList
   ) {
     this.viewers = new CopyOnWriteArraySet<>();
     this.locale = locale == null ? Locale.US : locale;

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudienceProvider.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudienceProvider.java
@@ -27,6 +27,8 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.platform.AudienceProvider;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
+import net.kyori.adventure.translation.GlobalTranslator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -61,6 +63,7 @@ public abstract class FacetAudienceProvider<V, A extends FacetAudience<V>> imple
   private final Set<A> consoles;
   private final A empty;
   private volatile boolean closed;
+  private ComponentRenderer<Locale> renderer;
 
   /**
    * Create a new empty provider.
@@ -75,6 +78,7 @@ public abstract class FacetAudienceProvider<V, A extends FacetAudience<V>> imple
     this.player = Audience.audience(this.players.values());
     this.empty = this.createAudience(Collections.emptyList());
     this.closed = false;
+    this.renderer = GlobalTranslator.renderer();
   }
 
   /**
@@ -308,5 +312,25 @@ public abstract class FacetAudienceProvider<V, A extends FacetAudience<V>> imple
         }
       }
     };
+  }
+
+  /**
+   * Gets the active locale-based renderer for operations on provided audiences.
+   *
+   * @return Active renderer
+   * @since 4.0.0
+   */
+  public ComponentRenderer<Locale> localeRenderer() {
+    return this.renderer;
+  }
+
+  /**
+   * Sets the active locale-based renderer for operations on provided audiences.
+   *
+   * @param renderer Active renderer
+   * @since 4.0.0
+   */
+  public void localeRenderer(final @NonNull ComponentRenderer<Locale> renderer) {
+    this.renderer = renderer;
   }
 }

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudienceProvider.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudienceProvider.java
@@ -314,22 +314,12 @@ public abstract class FacetAudienceProvider<V, A extends FacetAudience<V>> imple
     };
   }
 
-  /**
-   * Gets the active locale-based renderer for operations on provided audiences.
-   *
-   * @return Active renderer
-   * @since 4.0.0
-   */
+  @Override
   public ComponentRenderer<Locale> localeRenderer() {
     return this.renderer;
   }
 
-  /**
-   * Sets the active locale-based renderer for operations on provided audiences.
-   *
-   * @param renderer Active renderer
-   * @since 4.0.0
-   */
+  @Override
   public void localeRenderer(final @NonNull ComponentRenderer<Locale> renderer) {
     this.renderer = renderer;
   }

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetBossBarListener.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetBossBarListener.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.platform.facet;
 
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.GlobalTranslator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Locale;
@@ -33,10 +32,12 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 class FacetBossBarListener<V> implements Facet.BossBar<V> {
+  private final FacetAudienceProvider<V, ? extends FacetAudience<V>> audienceProvider;
   private final Facet.BossBar<V> facet;
   private final Supplier<Locale> locale;
 
-  FacetBossBarListener(final Facet.@NonNull BossBar<V> facet, final @NonNull Supplier<Locale> locale) {
+  FacetBossBarListener(final FacetAudienceProvider<V, ? extends FacetAudience<V>> audienceProvider, final Facet.@NonNull BossBar<V> facet, final @NonNull Supplier<Locale> locale) {
+    this.audienceProvider = audienceProvider;
     this.facet = facet;
     this.locale = locale;
   }
@@ -49,7 +50,7 @@ class FacetBossBarListener<V> implements Facet.BossBar<V> {
 
   @Override
   public void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
-    this.facet.bossBarNameChanged(bar, oldName, GlobalTranslator.render(newName, this.locale.get()));
+    this.facet.bossBarNameChanged(bar, oldName, this.audienceProvider.localeRenderer().render(newName, this.locale.get()));
   }
 
   @Override

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudience.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudience.java
@@ -60,7 +60,8 @@ final class SpongeAudience extends FacetAudience<MessageReceiver> {
     SpongeFacet.TabList::new
   );
 
-  SpongeAudience(final @NonNull Collection<MessageReceiver> viewers) {
-    super(viewers, null, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
+  SpongeAudience(final @NonNull SpongeAudiencesImpl audienceProvider,
+                 final @NonNull Collection<MessageReceiver> viewers) {
+    super(viewers, null, audienceProvider, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
   }
 }

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiencesImpl.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiencesImpl.java
@@ -111,7 +111,7 @@ final class SpongeAudiencesImpl extends FacetAudienceProvider<MessageReceiver, S
     } else if(receiver instanceof CommandBlock) {
       return Audience.empty();
     }
-    return new SpongeAudience(Collections.singletonList(receiver));
+    return new SpongeAudience(this, Collections.singletonList(receiver));
   }
 
   @NonNull
@@ -157,7 +157,7 @@ final class SpongeAudiencesImpl extends FacetAudienceProvider<MessageReceiver, S
   @NonNull
   @Override
   protected SpongeAudience createAudience(final @NonNull Collection<MessageReceiver> viewers) {
-    return new SpongeAudience(viewers);
+    return new SpongeAudience(this, viewers);
   }
 
   @Override


### PR DESCRIPTION
This PR adds the ability for plugins using the Bukkit, BungeeCord and Sponge platforms to specify their own `ComponentRenderer<Locale>` in place of the default translation renderer provided by adventure's `GlobalTranslator`.

This is loosely modelled off [adventure-platform-fabric](https://github.com/KyoriPowered/adventure-platform-fabric/blob/master/src/main/java/net/kyori/adventure/platform/fabric/impl/server/FabricServerAudiencesImpl.java) (though this PR doesn't implement support for multiple plugins' custom renderers on a single audience, as it doesn't seem necessary on Bukkit/BungeeCord/Sponge).

Things to consider:
- Currently renderers can be set after the `Audiences` is created, so we pass around the whole `FacetAudienceProvider`. I'm not sure whether this is preferred, or if it would be better to make the current renderer final (but this would likely mean we'd have to remove the `<platform>Audiences#create` per-plugin caching behaviour, which most plugins are used to at this point)

[Stripped-down example of usage](https://gist.github.com/mdcfe/5d804d48178926f9f8a3cee4a83a99b3)