### PR TITLE
Add per-viewer Component rendering

### DIFF
--- a/.checkstyle/suppressions.xml
+++ b/.checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
-  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
-  "http://checkstyle.org/dtds/suppressions_1_2.dtd">
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "http://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <!-- add any necessary suppressions here -->
   <suppress files="src/test/java/.*" checks="RequireExplicitVisibilityModifier"/>

--- a/api/src/main/java/net/kyori/adventure/platform/AudienceIdentity.java
+++ b/api/src/main/java/net/kyori/adventure/platform/AudienceIdentity.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of adventure-platform, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform;
+
+import java.util.Locale;
+import java.util.UUID;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.identity.Identity;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Identity for an {@link Audience}.
+ *
+ * @since 4.5.0
+ */
+public interface AudienceIdentity extends Identity {
+  /**
+   * Gets the UUID.
+   *
+   * @return a uuid
+   * @since 4.5.0
+   */
+  @Override
+  @NonNull
+  UUID uuid();
+
+  /**
+   * Gets the locale.
+   *
+   * @return a locale
+   * @since 4.5.0
+   */
+  @NonNull
+  Locale locale();
+
+  /**
+   * Gets the world name.
+   *
+   * @return a world name, or null if not in world
+   * @since 4.5.0
+   */
+  @Nullable
+  String world();
+
+  /**
+   * Gets the server name.
+   *
+   * @return a server name, or null if not on a proxy
+   * @since 4.5.0
+   */
+  @Nullable
+  String server();
+
+  /**
+   * Tests for a player.
+   *
+   * @return if a player
+   * @since 4.5.0
+   */
+  boolean player();
+
+  /**
+   * Tests for a console.
+   *
+   * @return if a console
+   * @since 4.5.0
+   */
+  boolean console();
+
+  /**
+   * Tests for a permission.
+   *
+   * @param key a permission key
+   * @return if it has permission
+   * @since 4.5.0
+   */
+  boolean permission(final @NonNull String key);
+}

--- a/api/src/main/java/net/kyori/adventure/platform/AudienceProvider.java
+++ b/api/src/main/java/net/kyori/adventure/platform/AudienceProvider.java
@@ -23,11 +23,12 @@
  */
 package net.kyori.adventure.platform;
 
+import java.util.UUID;
+import java.util.function.ToIntFunction;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.UUID;
 
 /**
  * A provider for creating {@link Audience}s.
@@ -103,8 +104,8 @@ public interface AudienceProvider extends AutoCloseable {
    *
    * <p>The audience is dynamically updated as players join and leave.</p>
    *
-   * <p>World identifiers were introduced in Minecraft 1.16. On older game instances,
-   * worlds will be assigned the {@link Key} {@code minecraft:<world name>}</p>
+   * <p>World identifiers were introduced in Minecraft 1.16. On older game instances, worlds will be
+   * assigned the {@link Key} {@code minecraft:<world name>}</p>
    *
    * @param world identifier for a world
    * @return the world's audience
@@ -130,4 +131,45 @@ public interface AudienceProvider extends AutoCloseable {
    */
   @Override
   void close();
+
+  /**
+   * A builder for {@link AudienceProvider}.
+   *
+   * @since 4.5.0
+   */
+  interface Builder<P extends AudienceProvider, B extends Builder<P, B>> {
+    /**
+     * Sets the component renderer for the provider.
+     *
+     * @param componentRenderer a component renderer
+     * @return this builder
+     * @since 4.5.0
+     */
+    @NonNull B componentRenderer(final @NonNull ComponentRenderer<AudienceIdentity> componentRenderer);
+
+    /**
+     * Sets the partition function for the provider.
+     *
+     * <p>Determines how to group audiences together, for optimization purposes. This will depend on
+     * the logic of {@link #componentRenderer(ComponentRenderer)}. For example, if the renderer only
+     * checks the audience's locale, then the partition function should return the hashCode of the
+     * locale.</p>
+     *
+     * <p>When in doubt, do not set this since the default partition will always work.</p>
+     *
+     * @param partitionFunction a partition function
+     * @return this builder
+     * @since 4.5.0
+     */
+    @NonNull B partitionBy(final @NonNull ToIntFunction<AudienceIdentity> partitionFunction);
+
+    /**
+     * Builds the provider.
+     *
+     * @return the built provider
+     * @since 4.5.0
+     */
+    @NonNull
+    P build();
+  }
 }

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
@@ -23,21 +23,19 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import java.util.Collection;
+import java.util.function.Function;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetAudience;
+import net.kyori.adventure.platform.facet.FacetAudienceProvider;
 import net.kyori.adventure.platform.viaversion.ViaFacet;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import us.myles.ViaVersion.api.data.UserConnection;
-
-import java.util.Collection;
-import java.util.Locale;
-import java.util.function.Function;
 
 final class BukkitAudience extends FacetAudience<CommandSender> {
   static final ThreadLocal<Plugin> PLUGIN = new ThreadLocal<>();
@@ -81,8 +79,8 @@ final class BukkitAudience extends FacetAudience<CommandSender> {
 
   private final @NonNull Plugin plugin;
 
-  BukkitAudience(final @NonNull Plugin plugin, final @NonNull Collection<CommandSender> viewers, final @Nullable Locale locale) {
-    super(viewers, locale, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
+  BukkitAudience(final @NonNull Plugin plugin, final FacetAudienceProvider<?, ?> provider, final @NonNull Collection<CommandSender> viewers) {
+    super(provider, viewers, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
     this.plugin = plugin;
   }
 

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiences.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiences.java
@@ -23,14 +23,13 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import java.util.function.Predicate;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.AudienceProvider;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.function.Predicate;
 
 /**
  * An audience provider for {@link org.bukkit.Bukkit}.
@@ -50,6 +49,19 @@ public interface BukkitAudiences extends AudienceProvider {
    */
   static @NonNull BukkitAudiences create(final @NonNull Plugin plugin) {
     return BukkitAudiencesImpl.instanceFor(plugin);
+  }
+
+  /**
+   * Creates an audience provider builder for a plugin.
+   *
+   * <p>There will only be one provider for each plugin.</p>
+   *
+   * @param plugin a plugin
+   * @return an audience provider
+   * @since 4.5.0
+   */
+  static @NonNull Builder builder(final @NonNull Plugin plugin) {
+    return BukkitAudiencesImpl.builder(plugin);
   }
 
   /**
@@ -78,5 +90,13 @@ public interface BukkitAudiences extends AudienceProvider {
    * @since 4.0.0
    */
   @NonNull Audience filter(final @NonNull Predicate<CommandSender> filter);
+
+  /**
+   * A builder for {@link BukkitAudiences}.
+   *
+   * @since 4.5.0
+   */
+  interface Builder extends AudienceProvider.Builder<BukkitAudiences, Builder> {
+  }
 }
 

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
@@ -23,6 +23,9 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Function;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
@@ -44,10 +47,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 
-import java.util.Collection;
-import java.util.Set;
-import java.util.function.Function;
-
 import static net.kyori.adventure.platform.facet.Knob.logUnsupported;
 import static net.kyori.adventure.text.serializer.craftbukkit.BukkitComponentSerializer.legacy;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findClass;
@@ -64,9 +63,8 @@ class BukkitFacet<V extends CommandSender> extends FacetBase<V> {
       super(viewerClass);
     }
 
-    @NonNull
     @Override
-    public String createMessage(final @NonNull V viewer, final @NonNull Component message) {
+    public @NonNull String createMessage(final @NonNull V viewer, final @NonNull Component message) {
       return legacy().serialize(message);
     }
   }
@@ -87,15 +85,13 @@ class BukkitFacet<V extends CommandSender> extends FacetBase<V> {
       super(Player.class);
     }
 
-    @NonNull
     @Override
-    public Vector createPosition(final @NonNull Player viewer) {
+    public @NonNull Vector createPosition(final @NonNull Player viewer) {
       return viewer.getLocation().toVector();
     }
 
-    @NonNull
     @Override
-    public Vector createPosition(final double x, final double y, final double z) {
+    public @NonNull Vector createPosition(final double x, final double y, final double z) {
       return new Vector(x, y, z);
     }
   }

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitIdentity.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitIdentity.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of adventure-platform, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.bukkit;
+
+import java.util.Locale;
+import java.util.UUID;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.platform.AudienceIdentity;
+import net.kyori.adventure.translation.Translator;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.command.ProxiedCommandSender;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class BukkitIdentity implements AudienceIdentity {
+  private final CommandSender sender;
+  private final Player player;
+  private Locale locale;
+
+  BukkitIdentity(@NonNull CommandSender sender) {
+    if(sender instanceof ProxiedCommandSender) {
+      sender = ((ProxiedCommandSender) sender).getCallee();
+    }
+    this.sender = requireNonNull(sender, "command sender");
+    this.player = this.player() ? (Player) sender : null;
+    if(this.player != null) {
+      try {
+        final Object locale = this.player.getLocale();
+        // Some Bukkit forks have Locale built-in
+        if(locale instanceof Locale) {
+          this.locale = (Locale) locale;
+        } else {
+          this.locale = Translator.parseLocale(locale.toString());
+        }
+      } catch(final NoSuchMethodError e) {
+        // Old Bukkit versions do not expose Locale
+      }
+      if(this.locale == null) {
+        this.locale = Locale.US;
+      }
+    }
+  }
+
+  @Override
+  public @NonNull UUID uuid() {
+    if(this.player()) {
+      return this.player.getUniqueId();
+    }
+    return Identity.nil().uuid();
+  }
+
+  @Override
+  public @NonNull Locale locale() {
+    return this.locale;
+  }
+
+  @Override
+  public @Nullable String world() {
+    if(this.player()) {
+      final World world = this.player.getWorld();
+      // Null worlds can exist in very strange situations
+      if(world != null) {
+        return world.getName();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public @Nullable String server() {
+    return null; // Bukkit is not a proxy
+  }
+
+  @Override
+  public boolean player() {
+    return this.sender instanceof Player;
+  }
+
+  @Override
+  public boolean console() {
+    return this.sender instanceof ConsoleCommandSender;
+  }
+
+  @Override
+  public boolean permission(final @NonNull String key) {
+    return this.sender.hasPermission(key);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.sender.hashCode();
+  }
+}

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/CraftBukkitFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/CraftBukkitFacet.java
@@ -25,7 +25,6 @@ package net.kyori.adventure.platform.bukkit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -80,9 +79,9 @@ import static java.lang.invoke.MethodType.methodType;
 import static net.kyori.adventure.platform.facet.Knob.isEnabled;
 import static net.kyori.adventure.platform.facet.Knob.logError;
 import static net.kyori.adventure.text.serializer.craftbukkit.BukkitComponentSerializer.gson;
+import static net.kyori.adventure.text.serializer.craftbukkit.BukkitComponentSerializer.legacy;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findClass;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findConstructor;
-import static net.kyori.adventure.text.serializer.craftbukkit.BukkitComponentSerializer.legacy;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findCraftClass;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findEnum;
 import static net.kyori.adventure.text.serializer.craftbukkit.MinecraftReflection.findField;

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/PaperFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/PaperFacet.java
@@ -23,6 +23,8 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetBase;
 import net.kyori.adventure.text.Component;
@@ -32,9 +34,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.reflect.Method;
 
 import static net.kyori.adventure.platform.facet.Knob.isEnabled;
 import static net.kyori.adventure.platform.facet.Knob.logError;
@@ -84,7 +83,7 @@ class PaperFacet<V extends CommandSender> extends FacetBase<V> {
     }
 
     @Override
-    public com.destroystokyo.paper.@NonNull Title createTitle(final BaseComponent @Nullable[] title, final BaseComponent @Nullable[] subTitle, final int inTicks, final int stayTicks, final int outTicks) {
+    public com.destroystokyo.paper.@NonNull Title createTitle(final BaseComponent @Nullable [] title, final BaseComponent @Nullable [] subTitle, final int inTicks, final int stayTicks, final int outTicks) {
       final com.destroystokyo.paper.Title.Builder builder = com.destroystokyo.paper.Title.builder();
 
       if(title != null) builder.title(title);

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/SpigotFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/SpigotFacet.java
@@ -72,9 +72,8 @@ class SpigotFacet<V extends CommandSender> extends FacetBase<V> {
       super(viewerClass);
     }
 
-    @NonNull
     @Override
-    public BaseComponent @NonNull[] createMessage(final @NonNull V viewer, final @NonNull Component message) {
+    public @NonNull BaseComponent @NonNull[] createMessage(final @NonNull V viewer, final @NonNull Component message) {
       return SERIALIZER.serialize(message);
     }
   }
@@ -150,9 +149,8 @@ class SpigotFacet<V extends CommandSender> extends FacetBase<V> {
       return super.isSupported() && SUPPORTED;
     }
 
-    @NonNull
     @Override
-    public ItemStack createBook(final BaseComponent @NonNull[] title, final BaseComponent @NonNull[] author, final @NonNull Iterable<BaseComponent[]> pages) {
+    public @NonNull ItemStack createBook(final BaseComponent @NonNull[] title, final BaseComponent @NonNull[] author, final @NonNull Iterable<BaseComponent[]> pages) {
       final ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
       final ItemMeta meta = book.getItemMeta();
       if(meta instanceof BookMeta) {

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudience.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudience.java
@@ -23,13 +23,12 @@
  */
 package net.kyori.adventure.platform.bungeecord;
 
+import java.util.Collection;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetAudience;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.Collection;
 
 final class BungeeAudience extends FacetAudience<CommandSender> {
   private static final Collection<Facet.Chat<? extends CommandSender, ?>> CHAT = Facet.of(
@@ -45,7 +44,7 @@ final class BungeeAudience extends FacetAudience<CommandSender> {
     BungeeFacet.TabList::new
   );
 
-  BungeeAudience(final @NonNull Collection<? extends CommandSender> viewers) {
-    super(viewers, null, CHAT, ACTION_BAR, TITLE, null, null, BOSS_BAR, TAB_LIST);
+  BungeeAudience(final @NonNull BungeeAudiencesImpl provider, final @NonNull Collection<? extends CommandSender> viewers) {
+    super(provider, viewers, CHAT, ACTION_BAR, TITLE, null, null, BOSS_BAR, TAB_LIST);
   }
 }

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiences.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiences.java
@@ -23,14 +23,13 @@
  */
 package net.kyori.adventure.platform.bungeecord;
 
+import java.util.function.Predicate;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.AudienceProvider;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.function.Predicate;
 
 /**
  * A provider for creating {@link Audience}s for BungeeCord.
@@ -49,6 +48,19 @@ public interface BungeeAudiences extends AudienceProvider {
    */
   static @NonNull BungeeAudiences create(final @NonNull Plugin plugin) {
     return BungeeAudiencesImpl.instanceFor(plugin);
+  }
+
+  /**
+   * Creates an audience provider builder for a plugin.
+   *
+   * <p>There will only be one provider for each plugin.</p>
+   *
+   * @param plugin a plugin
+   * @return an audience provider
+   * @since 4.0.0
+   */
+  static @NonNull Builder builder(final @NonNull Plugin plugin) {
+    return BungeeAudiencesImpl.builder(plugin);
   }
 
   /**
@@ -77,5 +89,13 @@ public interface BungeeAudiences extends AudienceProvider {
    * @since 4.0.0
    */
   @NonNull Audience filter(final @NonNull Predicate<CommandSender> filter);
+
+  /**
+   * A builder for {@link BungeeAudiences}.
+   *
+   * @since 4.5.0
+   */
+  interface Builder extends AudienceProvider.Builder<BungeeAudiences, Builder> {
+  }
 }
 

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
@@ -24,30 +24,30 @@
 package net.kyori.adventure.platform.bungeecord;
 
 import com.google.gson.Gson;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+import java.util.logging.Level;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.key.Key;
+import net.kyori.adventure.platform.AudienceIdentity;
 import net.kyori.adventure.platform.facet.FacetAudienceProvider;
 import net.kyori.adventure.platform.facet.Knob;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.renderer.ComponentRenderer;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
+import net.kyori.adventure.translation.GlobalTranslator;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
-import net.md_5.bungee.api.event.SettingsChangedEvent;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.event.EventHandler;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
-import java.util.logging.Level;
 
 import static java.util.Objects.requireNonNull;
 import static net.kyori.adventure.platform.facet.Knob.logError;
@@ -73,22 +73,25 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
 
   private static final Map<String, BungeeAudiences> INSTANCES = Collections.synchronizedMap(new HashMap<>(4));
 
-  static BungeeAudiences instanceFor(final @NonNull Plugin plugin) {
-    requireNonNull(plugin, "plugin");
-    return INSTANCES.computeIfAbsent(plugin.getDescription().getName(), name -> new BungeeAudiencesImpl(plugin));
+  static @NonNull BungeeAudiences instanceFor(final @NonNull Plugin plugin) {
+    return builder(plugin).build();
+  }
+
+  static @NonNull Builder builder(final @NonNull Plugin plugin) {
+    return new Builder(plugin);
   }
 
   private final Plugin plugin;
   private final Listener listener;
 
-  BungeeAudiencesImpl(final Plugin plugin) {
+  BungeeAudiencesImpl(final Plugin plugin, final @NonNull ComponentRenderer<AudienceIdentity> componentRenderer, final @NonNull ToIntFunction<AudienceIdentity> partitionFunction) {
+    super(componentRenderer, partitionFunction);
     this.plugin = requireNonNull(plugin, "plugin");
     this.listener = new Listener();
     this.plugin.getProxy().getPluginManager().registerListener(this.plugin, this.listener);
 
     final CommandSender console = this.plugin.getProxy().getConsole();
     this.addViewer(console);
-    this.changeViewer(console, Locale.getDefault());
 
     for(final ProxiedPlayer player : this.plugin.getProxy().getPlayers()) {
       this.addViewer(player);
@@ -100,7 +103,7 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
   public Audience sender(final @NonNull CommandSender sender) {
     if(sender instanceof ProxiedPlayer) {
       return this.player((ProxiedPlayer) sender);
-    } else if(this.isConsole(sender)) {
+    } else if(ProxyServer.getInstance().getConsole().equals(sender)) {
       return this.console();
     }
     return this.createAudience(Collections.singletonList(sender));
@@ -113,46 +116,54 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
   }
 
   @Override
-  protected @Nullable UUID hasId(final @NonNull CommandSender viewer) {
-    if(viewer instanceof ProxiedPlayer) {
-      return ((ProxiedPlayer) viewer).getUniqueId();
-    }
-    return null;
-  }
-
-  @Override
-  protected boolean isConsole(final @NonNull CommandSender viewer) {
-    return ProxyServer.getInstance().getConsole().equals(viewer);
-  }
-
-  @Override
-  protected boolean hasPermission(final @NonNull CommandSender viewer, final @NonNull String permission) {
-    return viewer.hasPermission(permission);
-  }
-
-  @Override
-  protected boolean isInWorld(final @NonNull CommandSender viewer, final @NonNull Key world) {
-    return false;
-  }
-
-  @Override
-  protected boolean isOnServer(final @NonNull CommandSender viewer, final @NonNull String server) {
-    if(viewer instanceof ProxiedPlayer) {
-      return ((ProxiedPlayer) viewer).getServer().getInfo().getName().equals(server);
-    }
-    return false;
+  protected @NonNull AudienceIdentity createIdentity(final @NonNull CommandSender viewer) {
+    return new BungeeIdentity(viewer);
   }
 
   @NonNull
   @Override
   protected BungeeAudience createAudience(final @NonNull Collection<CommandSender> viewers) {
-    return new BungeeAudience(viewers);
+    return new BungeeAudience(this, viewers);
   }
 
   @Override
   public void close() {
     this.plugin.getProxy().getPluginManager().unregisterListener(this.listener);
     super.close();
+  }
+
+  static final class Builder implements BungeeAudiences.Builder {
+    private final @NonNull Plugin plugin;
+    private @MonotonicNonNull ComponentRenderer<AudienceIdentity> componentRenderer;
+    private @MonotonicNonNull ToIntFunction<AudienceIdentity> partitionFunction;
+
+    Builder(final @NonNull Plugin plugin) {
+      this.plugin = requireNonNull(plugin, "plugin");
+      this.componentRenderer(new ComponentRenderer<AudienceIdentity>() {
+        @Override
+        public @NonNull Component render(final @NonNull Component component, final @NonNull AudienceIdentity context) {
+          return GlobalTranslator.render(component, context.locale());
+        }
+      });
+      this.partitionBy(context -> context.locale().hashCode());
+    }
+
+    @Override
+    public @NonNull Builder componentRenderer(final @NonNull ComponentRenderer<AudienceIdentity> componentRenderer) {
+      this.componentRenderer = requireNonNull(componentRenderer, "component renderer");
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder partitionBy(final @NonNull ToIntFunction<AudienceIdentity> partitionFunction) {
+      this.partitionFunction = requireNonNull(partitionFunction, "partition function");
+      return this;
+    }
+
+    @Override
+    public @NonNull BungeeAudiences build() {
+      return INSTANCES.computeIfAbsent(this.plugin.getDescription().getName(), name -> new BungeeAudiencesImpl(this.plugin, this.componentRenderer, this.partitionFunction));
+    }
   }
 
   public final class Listener implements net.md_5.bungee.api.plugin.Listener {
@@ -164,11 +175,6 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
     @EventHandler(priority = Byte.MAX_VALUE /* after EventPriority.HIGHEST */)
     public void onDisconnect(final PlayerDisconnectEvent event) {
       BungeeAudiencesImpl.this.removeViewer(event.getPlayer());
-    }
-
-    @EventHandler(priority = Byte.MAX_VALUE /* after EventPriority.HIGHEST */)
-    public void onSettingsChanged(final SettingsChangedEvent event) {
-      BungeeAudiencesImpl.this.changeViewer(event.getPlayer(), event.getPlayer().getLocale());
     }
   }
 }

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeFacet.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeFacet.java
@@ -23,6 +23,10 @@
  */
 package net.kyori.adventure.platform.bungeecord;
 
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.platform.facet.Facet;
@@ -38,14 +42,9 @@ import net.md_5.bungee.chat.ComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Collection;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 import static net.kyori.adventure.platform.facet.Knob.logUnsupported;
-import static net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer.legacy;
 import static net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer.get;
+import static net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer.legacy;
 
 class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
   static final BaseComponent[] EMPTY_COMPONENT_ARRAY = new BaseComponent[0];
@@ -65,12 +64,12 @@ class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
     }
 
     @Override
-    public BaseComponent @NonNull[] createMessage(final @NonNull CommandSender viewer, final @NonNull Component message) {
+    public BaseComponent@NonNull[] createMessage(final @NonNull CommandSender viewer, final @NonNull Component message) {
       return legacy().serialize(message);
     }
 
     @Override
-    public void sendMessage(final @NonNull CommandSender viewer, final @NonNull Identity source, final BaseComponent @NonNull [] message, final @NonNull MessageType type) {
+    public void sendMessage(final @NonNull CommandSender viewer, final @NonNull Identity source, final BaseComponent@NonNull[] message, final @NonNull MessageType type) {
       viewer.sendMessage(message);
     }
   }
@@ -81,7 +80,7 @@ class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
     }
 
     @Override
-    public BaseComponent @NonNull[] createMessage(final @NonNull ProxiedPlayer viewer, final @NonNull Component message) {
+    public BaseComponent@NonNull[] createMessage(final @NonNull ProxiedPlayer viewer, final @NonNull Component message) {
       if(viewer.getPendingConnection().getVersion() >= PROTOCOL_HEX_COLOR) {
         return get().serialize(message);
       } else {
@@ -102,7 +101,7 @@ class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
     }
 
     @Override
-    public void sendMessage(final @NonNull ProxiedPlayer viewer, final @NonNull Identity source, final BaseComponent @NonNull [] message, final @NonNull MessageType type) {
+    public void sendMessage(final @NonNull ProxiedPlayer viewer, final @NonNull Identity source, final BaseComponent@NonNull[] message, final @NonNull MessageType type) {
       final ChatMessageType chat = this.createType(type);
       if(chat != null) {
         viewer.sendMessage(chat, message);
@@ -112,7 +111,7 @@ class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
 
   static class ActionBar extends Message implements Facet.ActionBar<ProxiedPlayer, BaseComponent[]> {
     @Override
-    public void sendMessage(final @NonNull ProxiedPlayer viewer, final BaseComponent @NonNull[] message) {
+    public void sendMessage(final @NonNull ProxiedPlayer viewer, final BaseComponent@NonNull[] message) {
       viewer.sendMessage(ChatMessageType.ACTION_BAR, message);
     }
   }
@@ -122,7 +121,7 @@ class BungeeFacet<V extends CommandSender> extends FacetBase<V> {
     private static final net.md_5.bungee.api.Title RESET = ProxyServer.getInstance().createTitle().reset();
 
     @Override
-    public net.md_5.bungee.api.@NonNull Title createTitle(final BaseComponent @Nullable[] title, final BaseComponent @Nullable[] subTitle, final int inTicks, final int stayTicks, final int outTicks) {
+    public net.md_5.bungee.api.@NonNull Title createTitle(final BaseComponent@Nullable[] title, final BaseComponent@Nullable[] subTitle, final int inTicks, final int stayTicks, final int outTicks) {
       final net.md_5.bungee.api.Title builder = ProxyServer.getInstance().createTitle();
 
       if(title != null) builder.title(title);

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeIdentity.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeIdentity.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of adventure-platform, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.bungeecord;
+
+import java.util.Locale;
+import java.util.UUID;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.platform.AudienceIdentity;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.connection.Server;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class BungeeIdentity implements AudienceIdentity {
+  private final static CommandSender CONSOLE = ProxyServer.getInstance().getConsole();
+  private final CommandSender sender;
+  private final ProxiedPlayer player;
+
+  BungeeIdentity(final @NonNull CommandSender sender) {
+    this.sender = requireNonNull(sender, "command sender");
+    this.player = this.player() ? (ProxiedPlayer) sender : null;
+  }
+
+  @Override
+  public @NonNull UUID uuid() {
+    if(this.player()) {
+      return this.player.getUniqueId();
+    }
+    return Identity.nil().uuid();
+  }
+
+  @Override
+  public @NonNull Locale locale() {
+    if(this.player()) {
+      return this.player.getLocale();
+    }
+    return Locale.US;
+  }
+
+  @Override
+  public @Nullable String world() {
+    return null; // Bungee has no concept of worlds
+  }
+
+  @Override
+  public @Nullable String server() {
+    if(this.player()) {
+      final Server server = this.player.getServer();
+      if(server != null) {
+        final ServerInfo info = server.getInfo();
+        if(info != null) {
+          return info.getName();
+        }
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean player() {
+    return this.sender instanceof ProxiedPlayer;
+  }
+
+  @Override
+  public boolean console() {
+    return this.sender.equals(CONSOLE);
+  }
+
+  @Override
+  public boolean permission(final @NonNull String key) {
+    return this.sender.hasPermission(key);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.sender.hashCode();
+  }
+}

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/Facet.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/Facet.java
@@ -23,13 +23,6 @@
  */
 package net.kyori.adventure.platform.facet;
 
-import net.kyori.adventure.audience.MessageType;
-import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.sound.SoundStop;
-import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collection;
@@ -38,6 +31,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.sound.SoundStop;
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static net.kyori.adventure.platform.facet.Knob.logError;
 import static net.kyori.adventure.platform.facet.Knob.logMessage;
@@ -60,7 +59,8 @@ public interface Facet<V> {
    * @since 4.0.0
    */
   @SafeVarargs
-  static <V, F extends Facet<? extends V>> @NonNull Collection<F> of(final @NonNull Supplier<F>... suppliers) {
+  static <V, F extends Facet<? extends V>> @NonNull Collection<F> of(
+    final @NonNull Supplier<F>... suppliers) {
     final List<F> facets = new LinkedList<>();
     for(final Supplier<F> supplier : suppliers) {
       final F facet;
@@ -93,7 +93,8 @@ public interface Facet<V> {
    * @return a facet or {@code null} if none are applicable
    * @since 4.0.0
    */
-  static <V, F extends Facet<V>> @Nullable F of(final @Nullable Collection<F> facets, final @Nullable V viewer) {
+  static <V, F extends Facet<V>> @Nullable F of(
+    final @Nullable Collection<F> facets, final @Nullable V viewer) {
     if(facets == null || viewer == null) return null;
     for(final F facet : facets) {
       try {
@@ -154,7 +155,8 @@ public interface Facet<V> {
      * @return a message or {@code null}
      * @since 4.0.0
      */
-    @Nullable M createMessage(final @NonNull V viewer, final @NonNull Component message);
+    @Nullable
+    M createMessage(final @NonNull V viewer, final @NonNull Component message);
   }
 
   /**
@@ -174,7 +176,11 @@ public interface Facet<V> {
      * @param type a message type
      * @since 4.0.0
      */
-    void sendMessage(final @NonNull V viewer, final @NonNull Identity source, final @NonNull M message, final @NonNull MessageType type);
+    void sendMessage(
+      final @NonNull V viewer,
+      final @NonNull Identity source,
+      final @NonNull M message,
+      final @NonNull MessageType type);
   }
 
   /**
@@ -248,7 +254,13 @@ public interface Facet<V> {
      * @return a title or {@code null}
      * @since 4.0.0
      */
-    @Nullable T createTitle(final @Nullable M title, final @Nullable M subTitle, final int inTicks, final int stayTicks, final int outTicks);
+    @Nullable
+    T createTitle(
+      final @Nullable M title,
+      final @Nullable M subTitle,
+      final int inTicks,
+      final int stayTicks,
+      final int outTicks);
 
     /**
      * Shows a title.
@@ -329,7 +341,8 @@ public interface Facet<V> {
      * @return a position or {@code null} if cannot be found
      * @since 4.0.0
      */
-    @Nullable P createPosition(final @NonNull V viewer);
+    @Nullable
+    P createPosition(final @NonNull V viewer);
 
     /**
      * Creates a position.
@@ -340,7 +353,8 @@ public interface Facet<V> {
      * @return a position
      * @since 4.0.0
      */
-    @NonNull P createPosition(final double x, final double y, final double z);
+    @NonNull
+    P createPosition(final double x, final double y, final double z);
   }
 
   /**
@@ -359,7 +373,10 @@ public interface Facet<V> {
      * @param position a position
      * @since 4.0.0
      */
-    void playSound(final @NonNull V viewer, final net.kyori.adventure.sound.@NonNull Sound sound, final @NonNull P position);
+    void playSound(
+      final @NonNull V viewer,
+      final net.kyori.adventure.sound.@NonNull Sound sound,
+      final @NonNull P position);
 
     /**
      * Stops a sound.
@@ -389,7 +406,8 @@ public interface Facet<V> {
      * @return a book or {@code null}
      * @since 4.0.0
      */
-    @Nullable B createBook(final @NonNull M title, final @NonNull M author, final @NonNull Iterable<M> pages);
+    @Nullable
+    B createBook(final @NonNull M title, final @NonNull M author, final @NonNull Iterable<M> pages);
 
     /**
      * Opens a book.
@@ -426,7 +444,8 @@ public interface Facet<V> {
        * @return a boss bar
        * @since 4.0.0
        */
-      @NonNull B createBossBar(final @NonNull Collection<V> viewer);
+      @NonNull
+      B createBossBar(final @NonNull Collection<V> viewer);
     }
 
     /**
@@ -549,7 +568,10 @@ public interface Facet<V> {
      * @return an ordinal
      * @since 4.0.0
      */
-    default byte createFlag(final byte flagBit, final @NonNull Set<net.kyori.adventure.bossbar.BossBar.Flag> flagsAdded, final @NonNull Set<net.kyori.adventure.bossbar.BossBar.Flag> flagsRemoved) {
+    default byte createFlag(
+      final byte flagBit,
+      final @NonNull Set<net.kyori.adventure.bossbar.BossBar.Flag> flagsAdded,
+      final @NonNull Set<net.kyori.adventure.bossbar.BossBar.Flag> flagsRemoved) {
       byte bit = flagBit;
       for(final net.kyori.adventure.bossbar.BossBar.@NonNull Flag flag : flagsAdded) {
         if(flag == net.kyori.adventure.bossbar.BossBar.Flag.DARKEN_SCREEN) {
@@ -592,12 +614,18 @@ public interface Facet<V> {
     int INVULNERABLE_TICKS = 890;
 
     @Override
-    default void bossBarProgressChanged(final net.kyori.adventure.bossbar.@NonNull BossBar bar, final float oldProgress, final float newProgress) {
+    default void bossBarProgressChanged(
+      final net.kyori.adventure.bossbar.@NonNull BossBar bar,
+      final float oldProgress,
+      final float newProgress) {
       this.health(newProgress);
     }
 
     @Override
-    default void bossBarNameChanged(final net.kyori.adventure.bossbar.@NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
+    default void bossBarNameChanged(
+      final net.kyori.adventure.bossbar.@NonNull BossBar bar,
+      final @NonNull Component oldName,
+      final @NonNull Component newName) {
       this.name(newName);
     }
 

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetBossBarListener.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetBossBarListener.java
@@ -23,22 +23,21 @@
  */
 package net.kyori.adventure.platform.facet;
 
+import java.util.Set;
+import java.util.function.Function;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.translation.GlobalTranslator;
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.Locale;
-import java.util.Set;
-import java.util.function.Supplier;
 
 class FacetBossBarListener<V> implements Facet.BossBar<V> {
   private final Facet.BossBar<V> facet;
-  private final Supplier<Locale> locale;
+  private final Function<Component, Component> translator;
 
-  FacetBossBarListener(final Facet.@NonNull BossBar<V> facet, final @NonNull Supplier<Locale> locale) {
+  FacetBossBarListener(
+    final Facet.@NonNull BossBar<V> facet,
+    final @NonNull Function<Component, Component> translator) {
     this.facet = facet;
-    this.locale = locale;
+    this.translator = translator;
   }
 
   @Override
@@ -48,27 +47,40 @@ class FacetBossBarListener<V> implements Facet.BossBar<V> {
   }
 
   @Override
-  public void bossBarNameChanged(final @NonNull BossBar bar, final @NonNull Component oldName, final @NonNull Component newName) {
-    this.facet.bossBarNameChanged(bar, oldName, GlobalTranslator.render(newName, this.locale.get()));
+  public void bossBarNameChanged(
+    final @NonNull BossBar bar,
+    final @NonNull Component oldName,
+    final @NonNull Component newName) {
+    this.facet.bossBarNameChanged(bar, oldName, this.translator.apply(newName));
   }
 
   @Override
-  public void bossBarProgressChanged(final @NonNull BossBar bar, final float oldPercent, final float newPercent) {
+  public void bossBarProgressChanged(
+    final @NonNull BossBar bar, final float oldPercent, final float newPercent) {
     this.facet.bossBarProgressChanged(bar, oldPercent, newPercent);
   }
 
   @Override
-  public void bossBarColorChanged(final @NonNull BossBar bar, final BossBar.@NonNull Color oldColor, final BossBar.@NonNull Color newColor) {
+  public void bossBarColorChanged(
+    final @NonNull BossBar bar,
+    final BossBar.@NonNull Color oldColor,
+    final BossBar.@NonNull Color newColor) {
     this.facet.bossBarColorChanged(bar, oldColor, newColor);
   }
 
   @Override
-  public void bossBarOverlayChanged(final @NonNull BossBar bar, final BossBar.@NonNull Overlay oldOverlay, final BossBar.@NonNull Overlay newOverlay) {
+  public void bossBarOverlayChanged(
+    final @NonNull BossBar bar,
+    final BossBar.@NonNull Overlay oldOverlay,
+    final BossBar.@NonNull Overlay newOverlay) {
     this.facet.bossBarOverlayChanged(bar, oldOverlay, newOverlay);
   }
 
   @Override
-  public void bossBarFlagsChanged(final @NonNull BossBar bar, final @NonNull Set<BossBar.Flag> flagsAdded, final @NonNull Set<BossBar.Flag> flagsRemoved) {
+  public void bossBarFlagsChanged(
+    final @NonNull BossBar bar,
+    final @NonNull Set<BossBar.Flag> flagsAdded,
+    final @NonNull Set<BossBar.Flag> flagsRemoved) {
     this.facet.bossBarFlagsChanged(bar, flagsAdded, flagsRemoved);
   }
 

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/Knob.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/Knob.java
@@ -23,13 +23,12 @@
  */
 package net.kyori.adventure.platform.facet;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Facet utilities and logging pipeline.
@@ -40,17 +39,19 @@ public final class Knob {
   private Knob() {
   }
 
-  private static final String NAMESPACE = "net.kyo".concat("ri.adventure"); // Concat is used to trick package relocations
+  private static final String NAMESPACE =
+    "net.kyo".concat("ri.adventure"); // Concat is used to trick package relocations
   private static final boolean DEBUG = isEnabled("debug", false);
   private static final Set<Object> UNSUPPORTED = new CopyOnWriteArraySet<>();
 
   public static volatile Consumer<String> OUT = System.out::println;
-  public static volatile BiConsumer<String, Throwable> ERR = (message, err) -> {
-    System.err.println(message);
-    if(err != null) {
-      err.printStackTrace(System.err);
-    }
-  };
+  public static volatile BiConsumer<String, Throwable> ERR =
+    (message, err) -> {
+      System.err.println(message);
+      if(err != null) {
+        err.printStackTrace(System.err);
+      }
+    };
 
   /**
    * Gets whether a facet should be enabled.
@@ -63,7 +64,8 @@ public final class Knob {
    * @since 4.0.0
    */
   public static boolean isEnabled(final @NonNull String key, final boolean defaultValue) {
-    return System.getProperty(NAMESPACE + "." + key, Boolean.toString(defaultValue)).equalsIgnoreCase("true");
+    return System.getProperty(NAMESPACE + "." + key, Boolean.toString(defaultValue))
+      .equalsIgnoreCase("true");
   }
 
   /**
@@ -74,7 +76,10 @@ public final class Knob {
    * @param arguments an array of arguments
    * @since 4.0.0
    */
-  public static void logError(final @Nullable Throwable error, final @NonNull String format, final @NonNull Object... arguments) {
+  public static void logError(
+    final @Nullable Throwable error,
+    final @NonNull String format,
+    final @NonNull Object... arguments) {
     if(DEBUG) {
       ERR.accept(String.format(format, arguments), error);
     }

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudience.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudience.java
@@ -23,15 +23,15 @@
  */
 package net.kyori.adventure.platform.spongeapi;
 
+import java.util.Collection;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetAudience;
+import net.kyori.adventure.platform.facet.FacetAudienceProvider;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.spongepowered.api.effect.Viewer;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.channel.ChatTypeMessageReceiver;
 import org.spongepowered.api.text.channel.MessageReceiver;
-
-import java.util.Collection;
 
 final class SpongeAudience extends FacetAudience<MessageReceiver> {
   // private static final Function<Player, UserConnection> VIA = new SpongeFacet.ViaHook();
@@ -57,7 +57,7 @@ final class SpongeAudience extends FacetAudience<MessageReceiver> {
     SpongeFacet.TabList::new
   );
 
-  SpongeAudience(final @NonNull Collection<MessageReceiver> viewers) {
-    super(viewers, null, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
+  SpongeAudience(final FacetAudienceProvider<?, ?> provider, final @NonNull Collection<MessageReceiver> viewers) {
+    super(provider, viewers, CHAT, ACTION_BAR, TITLE, SOUND, BOOK, BOSS_BAR, TAB_LIST);
   }
 }

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiences.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiences.java
@@ -24,6 +24,7 @@
 package net.kyori.adventure.platform.spongeapi;
 
 import com.google.inject.ImplementedBy;
+import java.util.function.Predicate;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.AudienceProvider;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -31,8 +32,6 @@ import org.spongepowered.api.Game;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.channel.MessageReceiver;
-
-import java.util.function.Predicate;
 
 /**
  * A provider for creating {@link Audience}s for Sponge.
@@ -47,12 +46,26 @@ public interface SpongeAudiences extends AudienceProvider {
    * <p>There will only be one provider for each plugin.</p>
    *
    * @param plugin a plugin container
-   * @param game a game
+   * @param game   a game
    * @return an audience provider
    * @since 4.0.0
    */
   static @NonNull SpongeAudiences create(final @NonNull PluginContainer plugin, final @NonNull Game game) {
     return SpongeAudiencesImpl.instanceFor(plugin, game);
+  }
+
+  /**
+   * Creates an audience provider builder for a plugin.
+   *
+   * <p>There will only be one provider for each plugin.</p>
+   *
+   * @param plugin a plugin container
+   * @param game   a game
+   * @return an audience provider
+   * @since 4.5.0
+   */
+  static @NonNull Builder builder(final @NonNull PluginContainer plugin, final @NonNull Game game) {
+    return SpongeAudiencesImpl.builder(plugin, game);
   }
 
   /**
@@ -81,5 +94,13 @@ public interface SpongeAudiences extends AudienceProvider {
    * @since 4.0.0
    */
   @NonNull Audience filter(final @NonNull Predicate<MessageReceiver> filter);
+
+  /**
+   * A builder for {@link SpongeAudiences}.
+   *
+   * @since 4.5.0
+   */
+  interface Builder extends AudienceProvider.Builder<SpongeAudiences, Builder> {
+  }
 }
 

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeFacet.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeFacet.java
@@ -25,6 +25,8 @@ package net.kyori.adventure.platform.spongeapi;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.google.common.collect.Lists;
+import java.util.Collection;
+import java.util.Set;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
@@ -54,9 +56,6 @@ import org.spongepowered.api.text.chat.ChatType;
 import org.spongepowered.api.text.chat.ChatTypes;
 import org.spongepowered.api.world.Locatable;
 
-import java.util.Collection;
-import java.util.Set;
-
 import static java.util.Objects.requireNonNull;
 import static net.kyori.adventure.platform.facet.Knob.logUnsupported;
 import static net.kyori.adventure.text.serializer.spongeapi.SpongeComponentSerializer.get;
@@ -68,20 +67,20 @@ class SpongeFacet<V> extends FacetBase<V> {
 
   public <K, S extends CatalogType> @Nullable S sponge(final @NonNull Class<S> spongeType, final @NonNull K value, final @NonNull Index<String, K> elements) {
     return Sponge.getRegistry()
-            .getType(spongeType, elements.key(requireNonNull(value, "value")))
-            .orElseGet(() -> {
-              logUnsupported(this, value);
-              return null;
-            });
+      .getType(spongeType, elements.key(requireNonNull(value, "value")))
+      .orElseGet(() -> {
+        logUnsupported(this, value);
+        return null;
+      });
   }
 
   public <S extends CatalogType> @Nullable S sponge(final @NonNull Class<S> spongeType, final @NonNull Key identifier) {
     return Sponge.getRegistry()
-            .getType(spongeType, requireNonNull(identifier, "Identifier must be non-null").asString())
-            .orElseGet(() -> {
-              logUnsupported(this, identifier);
-              return null;
-            });
+      .getType(spongeType, requireNonNull(identifier, "Identifier must be non-null").asString())
+      .orElseGet(() -> {
+        logUnsupported(this, identifier);
+        return null;
+      });
   }
 
   static class Message<V> extends SpongeFacet<V> implements Facet.Message<V, Text> {
@@ -129,7 +128,7 @@ class SpongeFacet<V> extends FacetBase<V> {
       }
     }
   }
-  
+
   static class ActionBar extends Message<ChatTypeMessageReceiver> implements Facet.ActionBar<ChatTypeMessageReceiver, Text> {
     protected ActionBar() {
       super(ChatTypeMessageReceiver.class);
@@ -140,7 +139,7 @@ class SpongeFacet<V> extends FacetBase<V> {
       viewer.sendMessage(ChatTypes.ACTION_BAR, message);
     }
   }
-  
+
   static class Title extends Message<Viewer> implements Facet.Title<Viewer, Text, org.spongepowered.api.text.title.Title> {
     protected Title() {
       super(Viewer.class);

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeIdentity.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeIdentity.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of adventure-platform, licensed under the MIT License.
+ *
+ * Copyright (c) 2018-2020 KyoriPowered
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.kyori.adventure.platform.spongeapi;
+
+import java.util.Locale;
+import java.util.UUID;
+import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.platform.AudienceIdentity;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.command.source.ProxySource;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.text.channel.MessageReceiver;
+
+import static java.util.Objects.requireNonNull;
+
+final class SpongeIdentity implements AudienceIdentity {
+  private final MessageReceiver receiver;
+  private final Player player;
+
+  SpongeIdentity(@NonNull MessageReceiver receiver) {
+    if(receiver instanceof ProxySource) {
+      receiver = ((ProxySource) receiver).getOriginalSource();
+    }
+    this.receiver = requireNonNull(receiver, "message receiver");
+    this.player = this.player() ? (Player) receiver : null;
+  }
+
+  @Override
+  public @NonNull UUID uuid() {
+    if(this.player()) {
+      return this.player.getUniqueId();
+    }
+    return Identity.nil().uuid();
+  }
+
+  @Override
+  public @NonNull Locale locale() {
+    if(this.player()) {
+      return this.player.getLocale();
+    }
+    return Locale.US;
+  }
+
+  @Override
+  public @Nullable String world() {
+    if(this.player()) {
+      return this.player.getWorld().getName();
+    }
+    return null;
+  }
+
+  @Override
+  public @Nullable String server() {
+    return null; // Sponge is not a proxy
+  }
+
+  @Override
+  public boolean player() {
+    return this.receiver instanceof Player;
+  }
+
+  @Override
+  public boolean console() {
+    return this.receiver instanceof ConsoleSource;
+  }
+
+  @Override
+  public boolean permission(final @NonNull String key) {
+    if(this.receiver instanceof Subject) {
+      return ((Subject) this.receiver).hasPermission(key);
+    }
+    return false;
+  }
+}

--- a/platform-viaversion/build.gradle
+++ b/platform-viaversion/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.api.publish.maven.MavenPublication
-
 dependencies {
   compileOnlyApi 'us.myles:viaversion-common:3.0.0'
   implementation project(':adventure-platform-facet')

--- a/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
+++ b/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
@@ -23,6 +23,13 @@
  */
 package net.kyori.adventure.platform.viaversion;
 
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.platform.facet.Facet;
@@ -39,17 +46,9 @@ import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
 
-import java.text.MessageFormat;
-import java.util.Collection;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import static net.kyori.adventure.platform.facet.Knob.logError;
-import static net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson;
 import static net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.colorDownsamplingGson;
+import static net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson;
 
 // Non-API
 @SuppressWarnings({"checkstyle:FilteringWriteTag", "checkstyle:MissingJavadocType", "checkstyle:MissingJavadocMethod"})

--- a/text-serializer-bungeecord/build.gradle
+++ b/text-serializer-bungeecord/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-    api "net.kyori:adventure-api:${rootProject.adventure}"
-    compileOnly "net.md-5:bungeecord-chat:1.16-R0.1"
-    implementation "net.kyori:adventure-text-serializer-legacy:${rootProject.adventure}"
-    implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
-      exclude group: "com.google.code.gson"
-    }
+  api "net.kyori:adventure-api:${rootProject.adventure}"
+  compileOnly "net.md-5:bungeecord-chat:1.16-R0.1"
+  implementation "net.kyori:adventure-text-serializer-legacy:${rootProject.adventure}"
+  implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
+    exclude group: "com.google.code.gson"
+  }
 }
 
 jar {

--- a/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/BungeeComponentSerializer.java
+++ b/text-serializer-bungeecord/src/main/java/net/kyori/adventure/text/serializer/bungeecord/BungeeComponentSerializer.java
@@ -133,7 +133,7 @@ public final class BungeeComponentSerializer implements ComponentSerializer<Comp
   }
 
   @Override
-  public @NonNull Component deserialize(final @NonNull BaseComponent@NonNull[] input) {
+  public @NonNull Component deserialize(final @NonNull BaseComponent @NonNull [] input) {
     requireNonNull(input, "input");
 
     if(input.length == 1 && input[0] instanceof AdapterComponent) {
@@ -144,11 +144,11 @@ public final class BungeeComponentSerializer implements ComponentSerializer<Comp
   }
 
   @Override
-  public @NonNull BaseComponent@NonNull[] serialize(final @NonNull Component component) {
+  public @NonNull BaseComponent @NonNull [] serialize(final @NonNull Component component) {
     requireNonNull(component, "component");
 
     if(SUPPORTED) {
-      return new BaseComponent[] {new AdapterComponent(component)};
+      return new BaseComponent[]{new AdapterComponent(component)};
     } else {
       return net.md_5.bungee.chat.ComponentSerializer.parse(this.serializer.serialize(component));
     }

--- a/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/BukkitComponentSerializer.java
+++ b/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/BukkitComponentSerializer.java
@@ -48,12 +48,12 @@ public final class BukkitComponentSerializer {
   static {
     if(IS_1_16) {
       LEGACY_SERIALIZER = LegacyComponentSerializer.builder()
-              .hexColors()
-              .useUnusualXRepeatedCharacterHexFormat()
-              .build();
+        .hexColors()
+        .useUnusualXRepeatedCharacterHexFormat()
+        .build();
       GSON_SERIALIZER = GsonComponentSerializer.builder()
-              .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
-              .build();
+        .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.get())
+        .build();
     } else {
       LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
       GSON_SERIALIZER = GsonComponentSerializer.builder()

--- a/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/MinecraftComponentSerializer.java
+++ b/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/MinecraftComponentSerializer.java
@@ -33,7 +33,6 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
-
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.ComponentSerializer;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;

--- a/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/MinecraftReflection.java
+++ b/text-serializer-craftbukkit/src/main/java/net/kyori/adventure/text/serializer/craftbukkit/MinecraftReflection.java
@@ -23,12 +23,11 @@
  */
 package net.kyori.adventure.text.serializer.craftbukkit;
 
+import com.google.common.annotations.Beta;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
-
-import com.google.common.annotations.Beta;
 import org.bukkit.Bukkit;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/text-serializer-legacy-text3/build.gradle
+++ b/text-serializer-legacy-text3/build.gradle
@@ -1,13 +1,13 @@
 dependencies {
-    api "net.kyori:adventure-api:${rootProject.adventure}"
-    implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
-      exclude group: "com.google.code.gson"
-    }
-    compileOnly "net.kyori:text-serializer-gson:3.0.4"
+  api "net.kyori:adventure-api:${rootProject.adventure}"
+  implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
+    exclude group: "com.google.code.gson"
+  }
+  compileOnly "net.kyori:text-serializer-gson:3.0.4"
 }
 
 jar {
-    manifest.attributes(
-      'Automatic-Module-Name': 'net.kyori.adventure.text.serializer.legacytext3'
-    )
+  manifest.attributes(
+    'Automatic-Module-Name': 'net.kyori.adventure.text.serializer.legacytext3'
+  )
 }


### PR DESCRIPTION
There are many situations where developers need to modify a `Component` that is passed through an `Audience` to be customized for that particular viewer.

Each viewer is given an `AudienceIdentity`.

```java
public interface AudienceIdentity extends Identity {
  UUID uuid(); // UUID(0, 0) for non-players
  Locale locale();
  @Nullable String world();
  @Nullable String server();
  boolean player();
  boolean console();
  boolean permission(final String key);
}
```

Then, when building a `AudienceProvider`, developers can specify a `ComponentRenderer< AudienceIdentity>` to customize `Component`s that are passed through each `Audience`.

```java
Plugin plugin;
BukkitAudienceProvider provider = BukkitAudienceProvider.builder(plugin)
   .componentRenderer(new ComponentRenderer<AudienceIdentity>() {
      @Override
      public Component render(final Component component, final AudienceIdentity context) {
        final Player viewer = Bukkit.getPlayer(context.uuid());
        if(viewer == null) return component;
        return component.replaceText(TextReplacementConfig.builder()
          .matchLiteral("@" + viewer.getName())
          .replacement(LegacyComponentSerializer.legacySection().deserialize(viewer.getDisplayName()))
          .build());
      }
    })
  .build();

provider.server().sendMessage(text("Hello @ElectroidFilms!"));
```

This is an alternative implementation to #42. The key challenge with that is you can only customize `Component`s by `Locale`, where here you can customize it by locale, viewer, console, or anything else.

