### PR TITLE
Update ViaVersion dependency

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
@@ -344,7 +344,7 @@ class BukkitFacet<V extends CommandSender> extends FacetBase<V> {
   static final class ViaHook implements Function<Player, UserConnection> {
     @Override
     public UserConnection apply(final @NonNull Player player) {
-      return Via.getManager().getConnection(player.getUniqueId());
+      return Via.getManager().getConnectionManager().getConnectedClient(player.getUniqueId());
     }
   }
 

--- a/platform-viaversion/build.gradle
+++ b/platform-viaversion/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 dependencies {
-  compileOnlyApi 'us.myles:viaversion-common:3.0.0'
+  compileOnlyApi 'us.myles:viaversion-common:3.3.0-21w15a'
   implementation project(':adventure-platform-facet')
   implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
     exclude group: "com.google.code.gson"

--- a/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
+++ b/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
@@ -32,10 +32,10 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import us.myles.ViaVersion.api.PacketWrapper;
+import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.ClientboundPacketType;
 import us.myles.ViaVersion.api.protocol.Protocol;
-import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
 
@@ -60,7 +60,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
   static {
     boolean supported = false;
     try {
-      Class.forName(PACKAGE + ".api.protocol.ProtocolRegistry");
+      Class.forName(PACKAGE + ".ViaManager");
       supported = true;
     } catch(final Throwable error) {
       // Silently fail, ViaVersion is not loaded
@@ -88,7 +88,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
   @Override
   public boolean isApplicable(final @NonNull V viewer) {
     return super.isApplicable(viewer)
-      && this.minProtocol > ProtocolRegistry.SERVER_PROTOCOL
+      && this.minProtocol > Via.getAPI().getServerVersion().lowestSupportedVersion()
       && this.findProtocol(viewer) >= this.minProtocol;
   }
 


### PR DESCRIPTION
I was going to open this later (or wait for you to do it), but a few people have complained since we generally advise people to stay on dev builds atm. The License split we had made a breaking change to the ViaManager class (now interface) necessary.

`Via.getAPI().getServerVersion().lowestSupportedVersion()` will return the same exact value that `ProtocolRegistry.SERVER_PROTOCOL` gave (still gives, but is deprecated).