### PR TITLE
Update ViaVersion to 4.0.0 repackage

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
@@ -23,6 +23,7 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import com.viaversion.viaversion.api.connection.UserConnection;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetAudience;
@@ -33,7 +34,6 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import us.myles.ViaVersion.api.data.UserConnection;
 
 import java.util.Collection;
 import java.util.Locale;

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitFacet.java
@@ -23,6 +23,8 @@
  */
 package net.kyori.adventure.platform.bukkit;
 
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.connection.UserConnection;
 import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
@@ -41,8 +43,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import us.myles.ViaVersion.api.Via;
-import us.myles.ViaVersion.api.data.UserConnection;
 
 import java.util.Collection;
 import java.util.Set;

--- a/platform-viaversion/build.gradle
+++ b/platform-viaversion/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.api.publish.maven.MavenPublication
 
 dependencies {
-  compileOnlyApi 'us.myles:viaversion-api:4.0.0-21w16a'
+  compileOnlyApi 'com.viaversion:viaversion-api:4.0.0-21w19a'
   implementation project(':adventure-platform-facet')
   implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
     exclude group: "com.google.code.gson"
@@ -15,7 +15,7 @@ publishing {
       // Apply dependency hack for maven consumers
       pom.withXml() {
         asNode().dependencies.'*'.findAll() {
-          it.groupId.text() == 'us.myles'
+          it.groupId.text() == 'com.viaversion'
         }.each() {
           it.scope*.value = 'provided'
         }


### PR DESCRIPTION
Updated ViaVersion... *again* (at least without version clashes as with the first pr). This time you should actually wait 1-2 weeks before merging this (with people actually updating / no more breaks happening, even if unlikely). I also didn't have time to test this pr yet, but I'm opening this anyways so it's on your radar.

Note on the `ProtocolInfo` null check in `findProtocol(V)`: It's no longer nullable, and `getProtocolVersion()` returns -1 before finalized (as previously already), so the check is just removed and the rest left as is.