### PR TITLE
feat(platform): add clear methods to remove the audience provider cache

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
@@ -138,6 +138,12 @@ final class BukkitAudiencesImpl extends FacetAudienceProvider<CommandSender, Buk
   }
 
   @Override
+  public void close() {
+    INSTANCES.remove(this.plugin.getName());
+    super.close();
+  }
+
+  @Override
   public @NotNull ComponentFlattener flattener() {
     return BukkitComponentSerializer.FLATTENER;
   }

--- a/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
+++ b/platform-bungeecord/src/main/java/net/kyori/adventure/platform/bungeecord/BungeeAudiencesImpl.java
@@ -126,6 +126,7 @@ final class BungeeAudiencesImpl extends FacetAudienceProvider<CommandSender, Bun
 
   @Override
   public void close() {
+    BungeeAudiencesImpl.INSTANCES.remove(this.plugin.getDescription().getName());
     this.plugin.getProxy().getPluginManager().unregisterListener(this.listener);
     super.close();
   }

--- a/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiencesImpl.java
+++ b/platform-spongeapi/src/main/java/net/kyori/adventure/platform/spongeapi/SpongeAudiencesImpl.java
@@ -88,6 +88,7 @@ final class SpongeAudiencesImpl extends FacetAudienceProvider<MessageReceiver, S
     return new Builder(plugin, game);
   }
 
+  private final PluginContainer plugin;
   private final Game game;
   private final EventManager eventManager;
   private final EventListener eventListener;
@@ -100,6 +101,7 @@ final class SpongeAudiencesImpl extends FacetAudienceProvider<MessageReceiver, S
 
   SpongeAudiencesImpl(final @NotNull PluginContainer plugin, final @NotNull Game game, final @NotNull ComponentRenderer<Pointered> componentRenderer) {
     super(componentRenderer);
+    this.plugin = plugin;
     this.game = game;
     this.eventManager = game.getEventManager();
     this.eventListener = new EventListener();
@@ -149,6 +151,7 @@ final class SpongeAudiencesImpl extends FacetAudienceProvider<MessageReceiver, S
 
   @Override
   public void close() {
+    INSTANCES.remove(this.plugin.getId());
     this.eventManager.unregisterListeners(this.eventListener);
     super.close();
   }


### PR DESCRIPTION
Added `[...]Audiences.clear()` and `[...]Audiences.clear(Plugin)` to all three audiences. This will remove the audience from the static cache. This functionality may be needed by test environments.

This is related to [this request on discord](https://discord.com/channels/319355592605040642/420342659115122688/903015403113033749).