### PR TITLE
Fix ViaFacet component type

### DIFF
--- a/platform-viaversion/build.gradle
+++ b/platform-viaversion/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compileOnlyApi 'com.viaversion:viaversion-api:4.0.0-21w19a'
+  compileOnlyApi 'com.viaversion:viaversion-api:4.3.0'
   implementation project(':adventure-platform-facet')
   implementation("net.kyori:adventure-text-serializer-gson:${rootProject.adventure}") {
     exclude group: "com.google.code.gson"

--- a/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
+++ b/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
@@ -29,6 +29,7 @@ import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
+import com.viaversion.viaversion.libs.gson.JsonParser;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,14 +56,15 @@ import static net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.g
 @SuppressWarnings({"checkstyle:FilteringWriteTag", "checkstyle:MissingJavadocType", "checkstyle:MissingJavadocMethod"})
 public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String> {
   private static final String PACKAGE = "com.viaversion.viaversion";
+  private static final int SUPPORTED_VIA_MAJOR_VERSION = 4;
   private static final boolean SUPPORTED;
 
   static {
     boolean supported = false;
     try {
-      // Check if the ViaVersion API is present
-      Class.forName(PACKAGE + ".api.ViaManager");
-      supported = true;
+      // Check if the ViaVersion API is present and is a supported major version
+      Class.forName(PACKAGE + ".api.ViaAPI").getDeclaredMethod("majorVersion");
+      supported = Via.getAPI().majorVersion() == SUPPORTED_VIA_MAJOR_VERSION;
     } catch (final Throwable error) {
       // ignore
     }
@@ -179,7 +181,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     @Override
     public void sendMessage(final @NotNull V viewer, final @NotNull Identity source, final @NotNull String message, final @NotNull MessageType type) {
       final PacketWrapper packet = this.createPacket(viewer);
-      packet.write(Type.STRING, message);
+      packet.write(Type.COMPONENT, JsonParser.parseString(message));
       packet.write(Type.BYTE, this.createMessageType(type));
       packet.write(Type.UUID, source.uuid());
       this.sendPacket(packet);
@@ -211,7 +213,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void sendMessage(final @NotNull V viewer, final @NotNull String message) {
       final PacketWrapper packet = this.createPacket(viewer);
       packet.write(Type.VAR_INT, TitlePacket.ACTION_ACTIONBAR);
-      packet.write(Type.STRING, message);
+      packet.write(Type.COMPONENT, JsonParser.parseString(message));
       this.sendPacket(packet);
     }
   }
@@ -234,7 +236,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void contributeTitle(final @NotNull List<Consumer<PacketWrapper>> coll, final @NotNull String title) {
       coll.add(packet -> {
         packet.write(Type.VAR_INT, ACTION_TITLE);
-        packet.write(Type.STRING, title);
+        packet.write(Type.COMPONENT, JsonParser.parseString(title));
       });
     }
 
@@ -242,7 +244,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void contributeSubtitle(final @NotNull List<Consumer<PacketWrapper>> coll, final @NotNull String subtitle) {
       coll.add(packet -> {
         packet.write(Type.VAR_INT, ACTION_SUBTITLE);
-        packet.write(Type.STRING, subtitle);
+        packet.write(Type.COMPONENT, JsonParser.parseString(subtitle));
       });
     }
 
@@ -367,7 +369,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
       packet.write(Type.UUID, this.id);
       packet.write(Type.VAR_INT, action);
       if (action == ACTION_ADD || action == ACTION_TITLE) {
-        packet.write(Type.STRING, this.title);
+        packet.write(Type.COMPONENT, JsonParser.parseString(this.title));
       }
       if (action == ACTION_ADD || action == ACTION_HEALTH) {
         packet.write(Type.FLOAT, this.health);
@@ -424,8 +426,8 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     @Override
     public void send(final V viewer, final @Nullable String header, final @Nullable String footer) {
       final PacketWrapper packet = this.createPacket(viewer);
-      packet.write(Type.STRING, header);
-      packet.write(Type.STRING, footer);
+      packet.write(Type.COMPONENT, JsonParser.parseString(header));
+      packet.write(Type.COMPONENT, JsonParser.parseString(footer));
       this.sendPacket(packet);
     }
   }

--- a/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
+++ b/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
@@ -166,7 +166,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void sendPacket(final @NotNull PacketWrapper packet) {
       if (packet.user() == null) return;
       try {
-        packet.send(this.protocolClass);
+        packet.scheduleSend(this.protocolClass);
       } catch (final Throwable error) {
         logError(error, "Failed to send ViaVersion packet: %s %s", packet.user(), packet);
       }

--- a/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
+++ b/platform-viaversion/src/main/java/net/kyori/adventure/platform/viaversion/ViaFacet.java
@@ -29,6 +29,7 @@ import com.viaversion.viaversion.api.protocol.Protocol;
 import com.viaversion.viaversion.api.protocol.packet.ClientboundPacketType;
 import com.viaversion.viaversion.api.protocol.packet.PacketWrapper;
 import com.viaversion.viaversion.api.type.Type;
+import com.viaversion.viaversion.libs.gson.JsonElement;
 import com.viaversion.viaversion.libs.gson.JsonParser;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -171,6 +172,10 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
         logError(error, "Failed to send ViaVersion packet: %s %s", packet.user(), packet);
       }
     }
+
+    public @NotNull JsonElement parse(final @NotNull String message) {
+      return JsonParser.parseString(message);
+    }
   }
 
   public static class Chat<V> extends ProtocolBased<V> implements ChatPacket<V, String> {
@@ -181,7 +186,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     @Override
     public void sendMessage(final @NotNull V viewer, final @NotNull Identity source, final @NotNull String message, final @NotNull MessageType type) {
       final PacketWrapper packet = this.createPacket(viewer);
-      packet.write(Type.COMPONENT, JsonParser.parseString(message));
+      packet.write(Type.COMPONENT, this.parse(message));
       packet.write(Type.BYTE, this.createMessageType(type));
       packet.write(Type.UUID, source.uuid());
       this.sendPacket(packet);
@@ -213,7 +218,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void sendMessage(final @NotNull V viewer, final @NotNull String message) {
       final PacketWrapper packet = this.createPacket(viewer);
       packet.write(Type.VAR_INT, TitlePacket.ACTION_ACTIONBAR);
-      packet.write(Type.COMPONENT, JsonParser.parseString(message));
+      packet.write(Type.COMPONENT, this.parse(message));
       this.sendPacket(packet);
     }
   }
@@ -236,7 +241,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void contributeTitle(final @NotNull List<Consumer<PacketWrapper>> coll, final @NotNull String title) {
       coll.add(packet -> {
         packet.write(Type.VAR_INT, ACTION_TITLE);
-        packet.write(Type.COMPONENT, JsonParser.parseString(title));
+        packet.write(Type.COMPONENT, this.parse(title));
       });
     }
 
@@ -244,7 +249,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     public void contributeSubtitle(final @NotNull List<Consumer<PacketWrapper>> coll, final @NotNull String subtitle) {
       coll.add(packet -> {
         packet.write(Type.VAR_INT, ACTION_SUBTITLE);
-        packet.write(Type.COMPONENT, JsonParser.parseString(subtitle));
+        packet.write(Type.COMPONENT, this.parse(subtitle));
       });
     }
 
@@ -369,7 +374,7 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
       packet.write(Type.UUID, this.id);
       packet.write(Type.VAR_INT, action);
       if (action == ACTION_ADD || action == ACTION_TITLE) {
-        packet.write(Type.COMPONENT, JsonParser.parseString(this.title));
+        packet.write(Type.COMPONENT, this.parse(this.title));
       }
       if (action == ACTION_ADD || action == ACTION_HEALTH) {
         packet.write(Type.FLOAT, this.health);
@@ -426,8 +431,8 @@ public class ViaFacet<V> extends FacetBase<V> implements Facet.Message<V, String
     @Override
     public void send(final V viewer, final @Nullable String header, final @Nullable String footer) {
       final PacketWrapper packet = this.createPacket(viewer);
-      packet.write(Type.COMPONENT, JsonParser.parseString(header));
-      packet.write(Type.COMPONENT, JsonParser.parseString(footer));
+      packet.write(Type.COMPONENT, this.parse(header));
+      packet.write(Type.COMPONENT, this.parse(footer));
       this.sendPacket(packet);
     }
   }


### PR DESCRIPTION
Use the correct type when writing components as jsonelements instead of strings; this didn't cause any issue before because there were no handlers in Via trying to get the expected component type, but one has been added in 1.19 protocol transformation, causing an error when sending chat packets to 1.19+ clients.

The `majorVersion` method on ViaAPI was added in 4.0.2 (a long while ago), now being checked to make sure this doesn't break on 5.x in case API changes a lot again.

Unrelated to the issue, but this also uses `PacketWrapper.scheduleSend` instead of `send` to schedule this to the netty thread instead of any random thread this may be called on