### PR TITLE
Add methods for extended BossBar interaction

### DIFF
--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
@@ -406,6 +406,16 @@ public class FacetAudience<V> implements Audience, Closeable {
     }
   }
 
+  /**
+   * Check if this audience has been shown this BossBar
+   * @param bar The BossBar instance
+   * @return A boolean value
+   * @since 4.1.3
+   */
+  public boolean hasBossBar(final @NotNull BossBar bar) {
+    return this.bossBars != null && this.bossBars.containsKey(bar);
+  }
+
   @Override
   public void sendPlayerListHeader(final @NotNull Component header) {
     if (this.tabList != null) {

--- a/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
+++ b/platform-facet/src/main/java/net/kyori/adventure/platform/facet/FacetAudience.java
@@ -47,6 +47,7 @@ import net.kyori.adventure.title.TitlePart;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import static java.util.Objects.requireNonNull;
 
@@ -408,12 +409,19 @@ public class FacetAudience<V> implements Audience, Closeable {
 
   /**
    * Check if this audience has been shown this BossBar
-   * @param bar The BossBar instance
-   * @return A boolean value
    * @since 4.1.3
    */
   public boolean hasBossBar(final @NotNull BossBar bar) {
     return this.bossBars != null && this.bossBars.containsKey(bar);
+  }
+
+  /**
+   * Returns a set containing all BossBars this Audience has been shown
+   * @since 4.1.3
+   */
+  public @NotNull @UnmodifiableView Set<BossBar> getBossBars() {
+    if (this.bossBars == null) return Collections.emptySet();
+    return Collections.unmodifiableSet(this.bossBars.keySet());
   }
 
   @Override


### PR DESCRIPTION
This exposes the private field `bossBars` in order to allow checking if a `FacetAudience` has been shown a given `BossBar`, and to list the `BossBar`s previously shown to the `FacetAudience`.

In my opinion, this should not be merged until and unless the main `Audience` interface has these methods defined in some version of Adventure, I am working on that now