### PR TITLE
Fix CraftBukkitFacet on 1.20.2

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/CraftBukkitFacet.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/CraftBukkitFacet.java
@@ -167,6 +167,10 @@ class CraftBukkitFacet<V extends CommandSender> extends FacetBase<V> {
             }
           }
         }
+        final Class<?> serverCommonPacketListenerImpl = findClass(findMcClassName("server.network.ServerCommonPacketListenerImpl"));
+        if (serverCommonPacketListenerImpl != null) {
+          playerConnectionClass = serverCommonPacketListenerImpl;
+        }
         playerConnectionSendPacket = searchMethod(playerConnectionClass, Modifier.PUBLIC, new String[]{"sendPacket", "send"}, void.class, packetClass);
       } catch (final Throwable error) {
         logError(error, "Failed to initialize CraftBukkit sendPacket");


### PR DESCRIPTION
In 1.20.2, `send(Packet)` was moved from `ServerGamePacketListenerImpl` to its new superclass `ServerCommonPacketListenerImpl`.

Because `getDeclaredMethods` doesn't return methods defined in superclasses, `CraftBukkitFacet` didn't work at all.
Changed `MinecraftReflection#searchMethod` to use `getMethods` instead of `getDeclaredMethods`.