### PR TITLE
Set player locale when creating Audience

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
@@ -25,21 +25,17 @@ package net.kyori.adventure.platform.bukkit;
 
 import com.viaversion.viaversion.api.connection.UserConnection;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.function.Function;
 import net.kyori.adventure.bossbar.BossBar;
-import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.platform.facet.Facet;
 import net.kyori.adventure.platform.facet.FacetAudience;
 import net.kyori.adventure.platform.facet.FacetAudienceProvider;
 import net.kyori.adventure.platform.viaversion.ViaFacet;
-import net.kyori.adventure.pointer.Pointers;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("Convert2MethodRef")
 final class BukkitAudience extends FacetAudience<CommandSender> {
@@ -95,28 +91,10 @@ final class BukkitAudience extends FacetAudience<CommandSender> {
   );
 
   private final @NotNull Plugin plugin;
-  // Bukkit only provides this as a String
-  private @Nullable Locale locale;
 
   BukkitAudience(final @NotNull Plugin plugin, final FacetAudienceProvider<?, ?> provider, final @NotNull Collection<CommandSender> viewers) {
     super(provider, viewers, CHAT, ACTION_BAR, TITLE, SOUND, ENTITY_SOUND, BOOK, BOSS_BAR, TAB_LIST, POINTERS);
     this.plugin = plugin;
-  }
-
-  void locale(final @Nullable Locale locale) {
-    final boolean changed = this.locale != (this.locale = locale);
-    if (changed) {
-      this.refresh();
-    }
-  }
-
-  @Nullable Locale locale() {
-    return this.locale;
-  }
-
-  @Override
-  protected void contributePointers(final Pointers.Builder builder) {
-    builder.withDynamic(Identity.LOCALE, BukkitAudience.this::locale);
   }
 
   @Override

--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudiencesImpl.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -107,10 +106,6 @@ final class BukkitAudiencesImpl extends FacetAudienceProvider<CommandSender, Buk
       this.addViewer(event.getPlayer()));
     this.registerEvent(PlayerQuitEvent.class, EventPriority.MONITOR, event ->
       this.removeViewer(event.getPlayer()));
-    this.registerLocaleEvent(EventPriority.MONITOR, (viewer, locale) -> {
-      final @Nullable BukkitAudience audience = this.viewers.get(viewer);
-      if (audience != null) audience.locale(locale);
-    });
   }
 
   @Override
@@ -128,45 +123,8 @@ final class BukkitAudiencesImpl extends FacetAudienceProvider<CommandSender, Buk
   }
 
   @Override
-  public @NotNull Audience player(final @NotNull UUID playerId) {
-    final Player player = Bukkit.getPlayer(playerId);
-    if (player != null) {
-      return this.player(playerId, this.playerLocale(player));
-    }
-    return this.player(playerId, null);
-  }
-
-  @Override
   public @NotNull Audience player(final @NotNull Player player) {
-    return this.player(player.getUniqueId(), this.playerLocale(player));
-  }
-
-  private @NotNull Audience player(final @NotNull UUID playerId, final @Nullable String locale) {
-    final Audience audience = super.player(playerId);
-    if (locale != null) {
-      if (audience instanceof BukkitAudience) {
-        ((BukkitAudience) audience).locale(Translator.parseLocale(locale));
-      }
-    }
-    return audience;
-  }
-
-  private @Nullable String playerLocale(final Player player) {
-    final Class<?> playerClass = Player.class;
-
-    MethodHandle getMethod = findMethod(playerClass, "locale", String.class);
-    if (getMethod == null) {
-      getMethod = findMethod(playerClass, "getLocale", String.class);
-    }
-    if (getMethod == null) {
-      return null;
-    }
-    try {
-      return (String) getMethod.invoke(player);
-    } catch (final Throwable error) {
-      logError(error, "Failed to call %s for %s", getMethod, player);
-    }
-    return null;
+    return super.player(player.getUniqueId());
   }
 
   @Override


### PR DESCRIPTION
The pull request sets the client locale for Player audiences in the adventure-platform-bukkit module.
Until now, the client locale was only correct if the player changed their locale via settings while playing on the server.