### PR TITLE
Fix javadoc generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 
-javadocPublishRoot=https://jd.advntr.dev/
+javadocPublishRoot=https://jd.advntr.dev/platform/


### PR DESCRIPTION
- Fix root URL
- ~~Update Paper javadocs (apparently javadocs before 1.17 were removed)~~