### PR TITLE
Enable SpigotFacet for books

### DIFF
--- a/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
+++ b/platform-bukkit/src/main/java/net/kyori/adventure/platform/bukkit/BukkitAudience.java
@@ -68,7 +68,7 @@ final class BukkitAudience extends FacetAudience<CommandSender> {
     () -> new CraftBukkitFacet.EntitySound()
   );
   private static final Collection<Facet.Book<Player, ?, ?>> BOOK = Facet.of(
-    //    () -> new SpigotFacet.Book(),
+    () -> new SpigotFacet.Book(),
     () -> new CraftBukkitFacet.Book_1_20_5(),
     () -> new CraftBukkitFacet.BookPost1_13(),
     () -> new CraftBukkitFacet.Book1_13(),


### PR DESCRIPTION
This will improve forward compatibility with Spigot (and Spigot based platforms).
I don't know why it was commented, but I tested it and it works both on Spigot and on CraftBukkit.