### PR TITLE
Support getLocale returning a Locale

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
     }
     maven {
       name "papermc"
-      url 'https://papermc.io/repo/repository/maven-public/'
+      url 'https://repo.papermc.io/repository/maven-public/'
       mavenContent {
         includeGroup "io.papermc.paper"
         includeGroup "com.destroystokyo.paper"


### PR DESCRIPTION
After #160 our server has not had locales working. Prior to that our server impl already worked because it sent the locale change event right after a player logged in (once the client sent their settings packet), and the change introduced broke it as our server implementation's Player#getLocale returns a Locale, not a String.

This seems like a pretty reasonable thing to support.

For reference:
<https://github.com/Electroid/SportPaper/blob/main/patches/api/0084-Improve-locale-API-and-add-methods-for-translating-c.patch#L150>

Additionally i've removed the forgotten `registerLocaleEvent` method, that seems to have been left behind but not used anywhere anymore.